### PR TITLE
Updated structure for connections and added support for updating graph on keyword updates

### DIFF
--- a/backend/utils/DatabaseManager.js
+++ b/backend/utils/DatabaseManager.js
@@ -149,6 +149,22 @@ function updateUser(updatedUserObject, queryObject) {
     });
 }
 
+function bulkUpdateUsers(updatedUserObjects, queryObject) {
+
+    return new Promise(function(resolve, reject) {
+        getCollection(COLLECTION_USERS).then((collection) => {
+            let updateDoc = { $set: updatedUserObjects }
+            collection.updateMany(queryObject, updateDoc, function(err, updateResult) {
+                if (err) reject(false);
+
+                resolve(true);
+            })
+        }).catch((reason) => {
+            reject(false);
+        })
+    });
+}
+
 function deleteChat(id) {
 
     return new Promise(function (resolve, reject) {
@@ -170,6 +186,7 @@ module.exports.insertChat = insertChat;
 
 module.exports.updateChat = updateChat;
 module.exports.updateUser = updateUser;
+module.exports.bulkUpdateUsers = bulkUpdateUsers;
 
 module.exports.closeConnection = closeConnection;
 

--- a/backend/utils/Matcher.js
+++ b/backend/utils/Matcher.js
@@ -6,7 +6,7 @@ class Matcher {
         try {
             const user = (await DB.fetchUsers({ email: srcUser }))[0];
             const rightSwipedUser = (await DB.fetchUsers({ email: targetUser }))[0];
-            const swipedUserIndex = user.blueConnections.findIndex((value) => rightSwipedUser._id.equals(value));
+            const swipedUserIndex = user.blueConnections.findIndex((value) => rightSwipedUser._id.equals(value._id));
 
             if (swipedUserIndex === -1) return { success: false, isMatch: false };
 
@@ -34,7 +34,7 @@ class Matcher {
             const user = (await DB.fetchUsers({ email: srcUser }))[0];
             const leftSwipedUser = (await DB.fetchUsers({ email: targetUser }))[0];
 
-            const swipedUserIndex = user.blueConnections.findIndex((value) => leftSwipedUser._id.equals(value));
+            const swipedUserIndex = user.blueConnections.findIndex((value) => leftSwipedUser._id.equals(value._id));
             if (swipedUserIndex === -1) return false;
 
             user.blueConnections.splice(swipedUserIndex, 1);
@@ -53,13 +53,17 @@ class Matcher {
         }
     }
 
-    updateOutgoingConnection(connection, srcId) {
+    updateOutgoingConnection(connection, srcId, blueConn) {
 
         return new Promise(function (resolve, reject) {
-            if (connection.blueConnections.findIndex((id) => id.equals(srcId)) === -1
-                && connection.greenConnections.findIndex((id) => id.equals(srcId)) === -1) {
+            if (connection.blueConnections.findIndex((conn) => conn._id.equals(srcId)) === -1
+                && connection.greenConnections.findIndex((conn) => conn._id.equals(srcId)) === -1) {
 
-                connection.blueConnections.push(srcId);
+                connection.blueConnections.push({
+                    _id: srcId,
+                    commonKeywords: blueConn.commonKeywords
+                });
+
                 DB.updateUser({ blueConnections: connection.blueConnections }, { _id: connection._id }).then((result) => {
                     resolve(true);
                 }).catch((err) => {
@@ -72,25 +76,37 @@ class Matcher {
         });
     }
 
-    async generateGraph(email) {
+    async generateGraph(email, keywords) {
         try {
             const user = (await DB.fetchUsers({ email }))[0];
             let keyword_regexes = [];
-            for (let i = 0; i < user.keywords.length; i++) {
-                const keyword = user.keywords[i];
+            let usable_keywords = user.keywords;
+            
+            if (keywords !== undefined) {
+                usable_keywords = keywords;
+            }
+
+            for (let i = 0; i < usable_keywords.length; i++) {
+                const keyword = usable_keywords[i];
                 keyword_regexes.push(new RegExp("^" + keyword + "$", "i"));
             }
 
             try {
                 let potentialConnections = await DB.fetchUsers({ keywords: { $in: keyword_regexes } });
                 potentialConnections = potentialConnections.filter((value) => {
-                    return user.blueConnections.findIndex((id) => id.equals(value._id)) === -1 &&
+                    return user.blueConnections.findIndex((conn) => conn._id.equals(value._id)) === -1 &&
                         !(value._id.equals(user._id));
                 });
 
+                let blueConn = null;
                 for (let i = 0; i < potentialConnections.length; i++) {
-                    this.updateOutgoingConnection(potentialConnections[i], user._id);
-                    potentialConnections[i] = potentialConnections[i]._id;
+                    blueConn = {
+                        _id : potentialConnections[i]._id, 
+                        commonKeywords : user.keywords.filter(value => potentialConnections[i].keywords.includes(value))
+                    };
+
+                    this.updateOutgoingConnection(potentialConnections[i], user._id, blueConn);
+                    potentialConnections[i] = blueConn;
                 }
 
                 potentialConnections.forEach((element) => {
@@ -100,6 +116,7 @@ class Matcher {
                 try {
                     potentialConnections.length > 0 ? await DB.updateUser({ blueConnections: user.blueConnections },
                         { email: user.email }) : null;
+
                     return true;
                 } catch (updateErr) {
                     console.log(updateErr);
@@ -118,10 +135,99 @@ class Matcher {
         }
     }
 
+    async deleteUser(email) {
+        try {
+            const user = (await DB.fetchUsers({ email }))[0];
+
+            try {
+                let ids = [];
+                user.blueConnections.forEach((element) => ids.push(element._id));
+                
+                let connections = await DB.fetchUsers({ _id: { $in : ids } });
+                connections.forEach((element) => {
+                    const index = element.blueConnections.indexOf(user._id);
+                    element.blueConnections.splice(index, 1);
+                });
+
+                try {
+                    // await DB.bulkUpdateUsers(connections, { _id: { $in : user.blueConnections } })
+                    connections.forEach((element) => {
+                        DB.updateUser({ blueConnections: element.blueConnections }, { email: element.email })
+                    });
+    
+                    return true;
+                } catch (error) {
+                    console.log(error);
+                    return false;
+                }
+
+            } catch (fetchErr) {
+                console.log(fetchErr);
+                return false;
+            }
+        } catch (err) {
+            console.log(err);
+            return false;
+        }
+        
+    }
+
+    async updateGraph(email, oldKeywords){
+        try {
+            const user = (await DB.fetchUsers({ email }))[0];
+
+            var removedKeywords = oldKeywords.filter(value => !user.keywords.includes(value));
+            var addedKeywords = user.keywords.filter(value => !oldKeywords.includes(value));
+            var j = 0;
+
+            for(var i = 0; i < removedKeywords.length; i++) {
+                j = 0;
+                while (j < user.blueConnections.length) {
+
+                    if (user.blueConnections[j].commonKeywords.includes(removedKeywords[i])) {
+
+                        const newCommonKeywords = user.blueConnections[j].commonKeywords.filter((value) => value === removedKeywords[i])
+                        const user2 = (await DB.fetchUsers({ _id : conn }))[0];
+                        const id_index = user2.blueConnections.findIndex((value) => value._id.equals(user._id));
+
+                        if (newCommonKeywords.length === 0){
+                            conn = user.blueConnections.commonKeywords[j]._id
+                            user.blueConnections.splice(j, 1);
+                            j--;
+
+                            user2.blueConnections.splice(id_index, 1);
+                            DB.updateUser({ blueConnections: user2.blueConnections }, { _id: user2._id });
+                            
+                        }
+                        else {
+                            user.blueConnections[j].commonKeywords = newCommonKeywords
+                            user2.blueConnections[id_index].commonKeywords = newCommonKeywords
+                            DB.updateUser({blueConnections: user2.blueConnections}, {_id: user2._id}) 
+                        }
+
+                    }
+
+                    j++;
+                }
+            } 
+
+            await DB.updateUser({blueConnections: user.blueConnections}, { email });
+
+            if (addedKeywords.length > 0){
+                return this.generateGraph(email, addedkeywords)
+            }
+               
+        } catch (error) {
+            console.log(error);
+            return false;
+            
+        }
+    }
+
     async hasIncomingGreenConnection(srcUserId, _id) {
         try {
             const user = (await DB.fetchUsers({ _id }))[0];
-            return user.greenConnections.findIndex((id) => id.equals(srcUserId)) !== -1;
+            return user.greenConnections.findIndex((id) => id._id.equals(srcUserId)) !== -1;
         } catch (fetchErr) {
             console.log(fetchErr);
             return false;


### PR DESCRIPTION
Changes Co-authored by @aditidagar 

Connections now have keywords associated with them. This allows for breaking and adding of connections in the graph efficiently. Only the connections that are needed to be broken or added are accessed and updated in the database.

Before, connections list look like this:
`[ id1, id2, id3 ] // id is of type ObjectId`

Now, 
`[ conn1, conn2, conn3 ] // conn is a JSON object`
`conn = {
    _id: ObjectId,
    commonKeywords: [ keyword1, keyword2 ]
}
`

Note: The update graph function is still a bit buggy. I'll be opening a new issue for it. But this update needs to be pushed asap as the older server running on http://dev.findrapp.ca won't work with the new data structure