### PR TITLE
Added route to reply with supported universities

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -18,6 +18,7 @@ const {
 	updateKeywords,
 	signUp
 } = require('./utils/Handlers').functions;
+const { SUPPORTED_UNIVERSITIES } = require("./vars");
 
 const callbackQueue = new CallbackQueue();
 const CONNECTIONS_CHUNK_SIZE = 25;
@@ -381,6 +382,10 @@ app.get("/updateProfilePicture", async (req, res) => {
 	const email = req.query.email;
 	var url = await AWS_Presigner.generateSignedPutUrl("user_images/" + email);
 	res.status(200).send(url);
+});
+
+app.get("/supportedUniversities", (req, res) => {
+	res.status(200).send(SUPPORTED_UNIVERSITIES);
 });
 
 app.post("/signup", (req, res) => {

--- a/backend/vars.js
+++ b/backend/vars.js
@@ -1,10 +1,11 @@
-const MONTH_DICT = {1: 'January', 2: 'February', 3: 'March', 4: 'April', 5: 'May', 6: 'June', 7: 'July', 8: 'August', 9: 'September',
-10: 'October', 11: 'November', 12: 'December'};
+const APP_NAME = "Findr";
+const SUPPORTED_UNIVERSITIES = [
+    "University of Toronto",
+    "Ryerson University",
+    "Brown University",
+    "Northwestern University",
+    "Georgia Institute of Technology"
+];
 
-const WEEK_DICT = {1: 'Monday', 2: 'Tuesday', 3: 'Wednesday', 4: 'Thursday', 5: 'Friday', 6: 'Saturday', 7: 'Sunday'};
-
-const APP_NAME = "Findr"; // Placeholder name
-
-module.exports.MONTH_DICT = MONTH_DICT;
-module.exports.WEEK_DICT = WEEK_DICT;
 module.exports.APP_NAME = APP_NAME;
+module.exports.SUPPORTED_UNIVERSITIES = SUPPORTED_UNIVERSITIES;


### PR DESCRIPTION
Send a GET request to the API on the route /supportedUniversities to get an Array of supported universities.
Fixes #67 